### PR TITLE
Add contract path environment variable

### DIFF
--- a/packages/foundry/test/WrappedETH.t.sol
+++ b/packages/foundry/test/WrappedETH.t.sol
@@ -12,6 +12,12 @@ contract WrappedETHTest is Test {
 
     function setUp() public {
         wrappedETH = new WrappedETH();
+        // Use a different contract than default if CONTRACT_PATH env var is set
+        string memory contractPath = vm.envOr("CONTRACT_PATH", string("none"));
+        if (keccak256(abi.encodePacked(contractPath)) != keccak256(abi.encodePacked("none"))) {
+            bytes memory contractCode = vm.getDeployedCode(contractPath);
+            vm.etch(address(wrappedETH), contractCode);
+        }
     }
 
     function testDeposit() public {

--- a/packages/foundry/test/WrappedETH.t.sol
+++ b/packages/foundry/test/WrappedETH.t.sol
@@ -15,7 +15,7 @@ contract WrappedETHTest is Test {
         // Use a different contract than default if CONTRACT_PATH env var is set
         string memory contractPath = vm.envOr("CONTRACT_PATH", string("none"));
         if (keccak256(abi.encodePacked(contractPath)) != keccak256(abi.encodePacked("none"))) {
-            bytes memory contractCode = vm.getDeployedCode(contractPath);
+            bytes memory contractCode = vm.getCode(contractPath);
             vm.etch(address(wrappedETH), contractCode);
         }
     }


### PR DESCRIPTION
This small PR adds the ability to pass in a contract path other than the default contract when the challenge is being tested.