### PR TITLE
add contract path env var

### DIFF
--- a/packages/foundry/test/Governance.t.sol
+++ b/packages/foundry/test/Governance.t.sol
@@ -17,6 +17,13 @@ contract GovernanceTest is Test {
     function setUp() public {
         token = new DecentralizedResistanceToken(1000000 * 10 ** 18); // 1,000,000 tokens
         governance = new Governance(address(token), 86400); // 1 day voting period
+        // Use a different contract than default if CONTRACT_PATH env var is set
+        string memory contractPath = vm.envOr("CONTRACT_PATH", string("none"));
+        if (keccak256(abi.encodePacked(contractPath)) != keccak256(abi.encodePacked("none"))) {
+            bytes memory args = abi.encode(address(token), 86400);
+            bytes memory contractCode = abi.encodePacked(vm.getCode(contractPath), args);
+            vm.etch(address(governance), contractCode);
+        }
         // Distribute tokens
         token.transfer(userOne, 1000 * 10 ** 18); // 1000 tokens to userOne
         token.transfer(userTwo, 2000 * 10 ** 18); // 2000 tokens to userTwo


### PR DESCRIPTION
This small PR adds the ability to pass in a contract path other than the default contract when the challenge is being tested.