### PR TITLE
add contract path env var

### DIFF
--- a/packages/foundry/test/DeadMansSwitch.t.sol
+++ b/packages/foundry/test/DeadMansSwitch.t.sol
@@ -15,6 +15,12 @@ contract DeadMansSwitchTest is Test {
     // Setup the contract before each test
     function setUp() public {
         deadMansSwitch = new DeadMansSwitch();
+        // Use a different contract than default if CONTRACT_PATH env var is set
+        string memory contractPath = vm.envOr("CONTRACT_PATH", string("none"));
+        if (keccak256(abi.encodePacked(contractPath)) != keccak256(abi.encodePacked("none"))) {
+            bytes memory contractCode = vm.getCode(contractPath);
+            vm.etch(address(deadMansSwitch), contractCode);
+        }
     }
 
     // Test deposit functionality


### PR DESCRIPTION
This small PR adds the ability to pass in a contract path other than the default contract when the challenge is being tested.