### PR TITLE
add contract path env var

### DIFF
--- a/packages/foundry/test/EthStreaming.t.sol
+++ b/packages/foundry/test/EthStreaming.t.sol
@@ -20,6 +20,13 @@ contract EthStreamingTest is Test {
     function setUp() public {
         // Deploy the contract
         ethStreaming = new EthStreaming(FREQUENCY);
+        // Use a different contract than default if CONTRACT_PATH env var is set
+        string memory contractPath = vm.envOr("CONTRACT_PATH", string("none"));
+        if (keccak256(abi.encodePacked(contractPath)) != keccak256(abi.encodePacked("none"))) {
+            bytes memory args = abi.encode(FREQUENCY);
+            bytes memory contractCode = abi.encodePacked(vm.getCode(contractPath), args);
+            vm.etch(address(ethStreaming), contractCode);
+        }
         // Fund the contract
         (bool success, ) = payable(ethStreaming).call{value: STARTING_BALANCE}(
             ""


### PR DESCRIPTION
This small PR adds the ability to pass in a contract path other than the default contract when the challenge is being tested.