### PR TITLE
add contract path env var

### DIFF
--- a/packages/foundry/test/Multisend.t.sol
+++ b/packages/foundry/test/Multisend.t.sol
@@ -80,6 +80,12 @@ contract MultisendTest is Test {
         tokenRecipients = [luffy, zoro];
 
         multisend = new Multisend();
+        // Use a different contract than default if CONTRACT_PATH env var is set
+        string memory contractPath = vm.envOr("CONTRACT_PATH", string("none"));
+        if (keccak256(abi.encodePacked(contractPath)) != keccak256(abi.encodePacked("none"))) {
+            bytes memory contractCode = vm.getCode(contractPath);
+            vm.etch(address(multisend), contractCode);
+        }
     }
 
     function testSendETH() external {


### PR DESCRIPTION
This small PR adds the ability to pass in a contract path other than the default contract when the challenge is being tested.