### PR TITLE
add contract path env var

### DIFF
--- a/packages/foundry/test/Voting.t.sol
+++ b/packages/foundry/test/Voting.t.sol
@@ -15,6 +15,13 @@ contract VotingTest is Test {
     function setUp() public {
         token = new DecentralizedResistanceToken(1000000 * 10 ** 18); // 1,000,000 tokens
         voting = new Voting(address(token), 86400); // 1 day voting period
+        // Use a different contract than default if CONTRACT_PATH env var is set
+        string memory contractPath = vm.envOr("CONTRACT_PATH", string("none"));
+        if (keccak256(abi.encodePacked(contractPath)) != keccak256(abi.encodePacked("none"))) {
+            bytes memory args = abi.encode(address(token), 86400);
+            bytes memory contractCode = abi.encodePacked(vm.getCode(contractPath), args);
+            vm.etch(address(voting), contractCode);
+        }
         token.setVotingContract(address(voting)); // SetVotingContract
         // Distribute tokens
         token.transfer(userOne, 1000 * 10 ** 18); // 1000 tokens to userOne


### PR DESCRIPTION
This small PR adds the ability to pass in a contract path other than the default contract when the challenge is being tested.