### PR TITLE
Rebasing token

### DIFF
--- a/packages/foundry/test/RebasingERC20.t.sol
+++ b/packages/foundry/test/RebasingERC20.t.sol
@@ -60,8 +60,12 @@ contract RebasingERC20Test is Test {
         // Use a different contract than default if CONTRACT_PATH env var is set
         string memory contractPath = vm.envOr("CONTRACT_PATH", string("none"));
         if (keccak256(abi.encodePacked(contractPath)) != keccak256(abi.encodePacked("none"))) {
-            bytes memory contractCode = vm.getCode(contractPath);
-            vm.etch(address(token), contractCode);
+            bytes memory bytecode = vm.getCode(contractPath);
+            address deployed;
+            assembly {
+                deployed := create(0, add(bytecode, 0x20), mload(bytecode))
+            }
+            token = RebasingERC20(deployed);
         } else {
             token = new RebasingERC20();
         }

--- a/packages/foundry/test/RebasingERC20.t.sol
+++ b/packages/foundry/test/RebasingERC20.t.sol
@@ -57,12 +57,13 @@ contract RebasingERC20Test is Test {
     function setUp() public {
         luffy = address(this);
         zoro = address(0x123);
-        token = new RebasingERC20();
         // Use a different contract than default if CONTRACT_PATH env var is set
         string memory contractPath = vm.envOr("CONTRACT_PATH", string("none"));
         if (keccak256(abi.encodePacked(contractPath)) != keccak256(abi.encodePacked("none"))) {
             bytes memory contractCode = vm.getCode(contractPath);
             vm.etch(address(token), contractCode);
+        } else {
+            token = new RebasingERC20();
         }
         token.transfer(zoro, 1000 * 10 ** token.decimals());
         luffyBalance1 = token.balanceOf(luffy);


### PR DESCRIPTION
This PR changes the way we instantiate the new contract so that the contract doesn't exist prior to overwriting. Using vm.etch to write over the existing contract address leaves any existing contract state which makes the constructor not work.