### PR TITLE
Multisend

### DIFF
--- a/packages/foundry/test/Multisend.t.sol
+++ b/packages/foundry/test/Multisend.t.sol
@@ -79,12 +79,13 @@ contract MultisendTest is Test {
         recipients = [luffy, zoro];
         tokenRecipients = [luffy, zoro];
 
-        multisend = new Multisend();
         // Use a different contract than default if CONTRACT_PATH env var is set
         string memory contractPath = vm.envOr("CONTRACT_PATH", string("none"));
         if (keccak256(abi.encodePacked(contractPath)) != keccak256(abi.encodePacked("none"))) {
             bytes memory contractCode = vm.getCode(contractPath);
             vm.etch(address(multisend), contractCode);
+        } else {
+            multisend = new Multisend();
         }
     }
 

--- a/packages/foundry/test/Multisend.t.sol
+++ b/packages/foundry/test/Multisend.t.sol
@@ -82,8 +82,12 @@ contract MultisendTest is Test {
         // Use a different contract than default if CONTRACT_PATH env var is set
         string memory contractPath = vm.envOr("CONTRACT_PATH", string("none"));
         if (keccak256(abi.encodePacked(contractPath)) != keccak256(abi.encodePacked("none"))) {
-            bytes memory contractCode = vm.getCode(contractPath);
-            vm.etch(address(multisend), contractCode);
+            bytes memory bytecode = vm.getCode(contractPath);
+            address deployed;
+            assembly {
+                deployed := create(0, add(bytecode, 0x20), mload(bytecode))
+            }
+            multisend = Multisend(deployed);
         } else {
             multisend = new Multisend();
         }


### PR DESCRIPTION
This PR changes the way we instantiate the new contract so that the contract doesn't exist prior to overwriting. Using vm.etch to write over the existing contract address leaves any existing contract state which makes the constructor not work.