### PR TITLE
Eth streaming

### DIFF
--- a/packages/foundry/test/EthStreaming.t.sol
+++ b/packages/foundry/test/EthStreaming.t.sol
@@ -19,13 +19,14 @@ contract EthStreamingTest is Test {
      */
     function setUp() public {
         // Deploy the contract
-        ethStreaming = new EthStreaming(FREQUENCY);
         // Use a different contract than default if CONTRACT_PATH env var is set
         string memory contractPath = vm.envOr("CONTRACT_PATH", string("none"));
         if (keccak256(abi.encodePacked(contractPath)) != keccak256(abi.encodePacked("none"))) {
             bytes memory args = abi.encode(FREQUENCY);
             bytes memory contractCode = abi.encodePacked(vm.getCode(contractPath), args);
             vm.etch(address(ethStreaming), contractCode);
+        } else {
+            ethStreaming = new EthStreaming(FREQUENCY);
         }
         // Fund the contract
         (bool success, ) = payable(ethStreaming).call{value: STARTING_BALANCE}(

--- a/packages/foundry/test/EthStreaming.t.sol
+++ b/packages/foundry/test/EthStreaming.t.sol
@@ -23,8 +23,12 @@ contract EthStreamingTest is Test {
         string memory contractPath = vm.envOr("CONTRACT_PATH", string("none"));
         if (keccak256(abi.encodePacked(contractPath)) != keccak256(abi.encodePacked("none"))) {
             bytes memory args = abi.encode(FREQUENCY);
-            bytes memory contractCode = abi.encodePacked(vm.getCode(contractPath), args);
-            vm.etch(address(ethStreaming), contractCode);
+            bytes memory bytecode = abi.encodePacked(vm.getCode(contractPath), args);
+            address deployed;
+            assembly {
+                deployed := create(0, add(bytecode, 0x20), mload(bytecode))
+            }
+            ethStreaming = EthStreaming(deployed);
         } else {
             ethStreaming = new EthStreaming(FREQUENCY);
         }


### PR DESCRIPTION
This PR changes the way we instantiate the new contract so that the contract doesn't exist prior to overwriting. Using vm.etch to write over the existing contract address leaves any existing contract state which makes the constructor not work.