### PR TITLE
Dead mans switch

### DIFF
--- a/packages/foundry/test/DeadMansSwitch.t.sol
+++ b/packages/foundry/test/DeadMansSwitch.t.sol
@@ -14,12 +14,13 @@ contract DeadMansSwitchTest is Test {
 
     // Setup the contract before each test
     function setUp() public {
-        deadMansSwitch = new DeadMansSwitch();
         // Use a different contract than default if CONTRACT_PATH env var is set
         string memory contractPath = vm.envOr("CONTRACT_PATH", string("none"));
         if (keccak256(abi.encodePacked(contractPath)) != keccak256(abi.encodePacked("none"))) {
             bytes memory contractCode = vm.getCode(contractPath);
             vm.etch(address(deadMansSwitch), contractCode);
+        } else {
+            deadMansSwitch = new DeadMansSwitch();
         }
     }
 

--- a/packages/foundry/test/DeadMansSwitch.t.sol
+++ b/packages/foundry/test/DeadMansSwitch.t.sol
@@ -17,8 +17,12 @@ contract DeadMansSwitchTest is Test {
         // Use a different contract than default if CONTRACT_PATH env var is set
         string memory contractPath = vm.envOr("CONTRACT_PATH", string("none"));
         if (keccak256(abi.encodePacked(contractPath)) != keccak256(abi.encodePacked("none"))) {
-            bytes memory contractCode = vm.getCode(contractPath);
-            vm.etch(address(deadMansSwitch), contractCode);
+            bytes memory bytecode = vm.getCode(contractPath);
+            address deployed;
+            assembly {
+                deployed := create(0, add(bytecode, 0x20), mload(bytecode))
+            }
+            deadMansSwitch = DeadMansSwitch(deployed);
         } else {
             deadMansSwitch = new DeadMansSwitch();
         }


### PR DESCRIPTION
This PR changes the way we instantiate the new contract so that the contract doesn't exist prior to overwriting. Using vm.etch to write over the existing contract address leaves any existing contract state which makes the constructor not work.