### PR TITLE
Token wrapper weth

### DIFF
--- a/packages/foundry/test/WrappedETH.t.sol
+++ b/packages/foundry/test/WrappedETH.t.sol
@@ -11,12 +11,13 @@ contract WrappedETHTest is Test {
     uint ONE_THOUSAND = 1000 wei;
 
     function setUp() public {
-        wrappedETH = new WrappedETH();
         // Use a different contract than default if CONTRACT_PATH env var is set
         string memory contractPath = vm.envOr("CONTRACT_PATH", string("none"));
         if (keccak256(abi.encodePacked(contractPath)) != keccak256(abi.encodePacked("none"))) {
             bytes memory contractCode = vm.getCode(contractPath);
             vm.etch(address(wrappedETH), contractCode);
+        } else {
+            wrappedETH = new WrappedETH();
         }
     }
 

--- a/packages/foundry/test/WrappedETH.t.sol
+++ b/packages/foundry/test/WrappedETH.t.sol
@@ -14,7 +14,7 @@ contract WrappedETHTest is Test {
         // Use a different contract than default if CONTRACT_PATH env var is set
         string memory contractPath = vm.envOr("CONTRACT_PATH", string("none"));
         if (keccak256(abi.encodePacked(contractPath)) != keccak256(abi.encodePacked("none"))) {
-            bytes memory contractCode = vm.getCode(contractPath);
+            bytes memory bytecode = vm.getCode(contractPath);
             address deployed;
             assembly {
                 deployed := create(0, add(bytecode, 0x20), mload(bytecode))

--- a/packages/foundry/test/WrappedETH.t.sol
+++ b/packages/foundry/test/WrappedETH.t.sol
@@ -15,7 +15,11 @@ contract WrappedETHTest is Test {
         string memory contractPath = vm.envOr("CONTRACT_PATH", string("none"));
         if (keccak256(abi.encodePacked(contractPath)) != keccak256(abi.encodePacked("none"))) {
             bytes memory contractCode = vm.getCode(contractPath);
-            vm.etch(address(wrappedETH), contractCode);
+            address deployed;
+            assembly {
+                deployed := create(0, add(bytecode, 0x20), mload(bytecode))
+            }
+            wrappedETH = WrappedETH(deployed);
         } else {
             wrappedETH = new WrappedETH();
         }


### PR DESCRIPTION
This PR changes the way we instantiate the new contract so that the contract doesn't exist prior to overwriting. Using vm.etch to write over the existing contract address leaves any existing contract state which makes the constructor not work.