### PR TITLE
remove vm.etch

### DIFF
--- a/packages/foundry/test/Governance.t.sol
+++ b/packages/foundry/test/Governance.t.sol
@@ -16,13 +16,18 @@ contract GovernanceTest is Test {
 
     function setUp() public {
         token = new DecentralizedResistanceToken(1000000 * 10 ** 18); // 1,000,000 tokens
-        governance = new Governance(address(token), 86400); // 1 day voting period
         // Use a different contract than default if CONTRACT_PATH env var is set
         string memory contractPath = vm.envOr("CONTRACT_PATH", string("none"));
         if (keccak256(abi.encodePacked(contractPath)) != keccak256(abi.encodePacked("none"))) {
             bytes memory args = abi.encode(address(token), 86400);
-            bytes memory contractCode = abi.encodePacked(vm.getCode(contractPath), args);
-            vm.etch(address(governance), contractCode);
+            bytes memory bytecode = abi.encodePacked(vm.getCode(contractPath), args);
+            address deployed;
+            assembly {
+                deployed := create(0, add(bytecode, 0x20), mload(bytecode))
+            }
+            governance = Governance(deployed);
+        } else {
+            governance = new Governance(address(token), 86400); // 1 day voting period
         }
         // Distribute tokens
         token.transfer(userOne, 1000 * 10 ** 18); // 1000 tokens to userOne


### PR DESCRIPTION
This PR changes the way we instantiate the new contract so that the contract doesn't exist prior to overwriting. Using vm.etch to write over the existing contract address leaves any existing contract state which makes the constructor not work.