### PR TITLE
Social recovery

### DIFF
--- a/packages/foundry/test/SocialRecoveryWallet.t.sol
+++ b/packages/foundry/test/SocialRecoveryWallet.t.sol
@@ -32,8 +32,12 @@ contract SocialRecoveryWalletTest is Test {
         string memory contractPath = vm.envOr("CONTRACT_PATH", string("none"));
         if (keccak256(abi.encodePacked(contractPath)) != keccak256(abi.encodePacked("none"))) {
             bytes memory args = abi.encode(chosenGuardianList, threshold);
-            bytes memory contractCode = abi.encodePacked(vm.getCode(contractPath), args);
-            vm.etch(address(socialRecoveryWallet), contractCode);
+            bytes memory bytecode = abi.encodePacked(vm.getCode(contractPath), args);
+            address deployed;
+            assembly {
+                deployed := create(0, add(bytecode, 0x20), mload(bytecode))
+            }
+            socialRecoveryWallet = SocialRecoveryWallet(deployed);
         } else {
             socialRecoveryWallet = new SocialRecoveryWallet(chosenGuardianList, threshold);
         }

--- a/packages/foundry/test/SocialRecoveryWallet.t.sol
+++ b/packages/foundry/test/SocialRecoveryWallet.t.sol
@@ -28,13 +28,14 @@ contract SocialRecoveryWalletTest is Test {
     address newOwner = makeAddr("newOwner");
 
     function setUp() public {
-        socialRecoveryWallet = new SocialRecoveryWallet(chosenGuardianList, threshold);
         // Use a different contract than default if CONTRACT_PATH env var is set
         string memory contractPath = vm.envOr("CONTRACT_PATH", string("none"));
         if (keccak256(abi.encodePacked(contractPath)) != keccak256(abi.encodePacked("none"))) {
             bytes memory args = abi.encode(chosenGuardianList, threshold);
             bytes memory contractCode = abi.encodePacked(vm.getCode(contractPath), args);
             vm.etch(address(socialRecoveryWallet), contractCode);
+        } else {
+            socialRecoveryWallet = new SocialRecoveryWallet(chosenGuardianList, threshold);
         }
         dai = new Token("Dai", "DAI");
         vm.deal(address(socialRecoveryWallet), 1 ether);


### PR DESCRIPTION
This PR changes the way we instantiate the new contract so that the contract doesn't exist prior to overwriting. Using vm.etch to write over the existing contract address leaves any existing contract state which makes the constructor not work.