### PR TITLE
Token voting

### DIFF
--- a/packages/foundry/test/Voting.t.sol
+++ b/packages/foundry/test/Voting.t.sol
@@ -18,8 +18,12 @@ contract VotingTest is Test {
         string memory contractPath = vm.envOr("CONTRACT_PATH", string("none"));
         if (keccak256(abi.encodePacked(contractPath)) != keccak256(abi.encodePacked("none"))) {
             bytes memory args = abi.encode(address(token), 86400);
-            bytes memory contractCode = abi.encodePacked(vm.getCode(contractPath), args);
-            vm.etch(address(voting), contractCode);
+            bytes memory bytecode = abi.encodePacked(vm.getCode(contractPath), args);
+            address deployed;
+            assembly {
+                deployed := create(0, add(bytecode, 0x20), mload(bytecode))
+            }
+            voting = Voting(deployed);
         } else {
             voting = new Voting(address(token), 86400); // 1 day voting period
         }

--- a/packages/foundry/test/Voting.t.sol
+++ b/packages/foundry/test/Voting.t.sol
@@ -14,13 +14,14 @@ contract VotingTest is Test {
 
     function setUp() public {
         token = new DecentralizedResistanceToken(1000000 * 10 ** 18); // 1,000,000 tokens
-        voting = new Voting(address(token), 86400); // 1 day voting period
         // Use a different contract than default if CONTRACT_PATH env var is set
         string memory contractPath = vm.envOr("CONTRACT_PATH", string("none"));
         if (keccak256(abi.encodePacked(contractPath)) != keccak256(abi.encodePacked("none"))) {
             bytes memory args = abi.encode(address(token), 86400);
             bytes memory contractCode = abi.encodePacked(vm.getCode(contractPath), args);
             vm.etch(address(voting), contractCode);
+        } else {
+            voting = new Voting(address(token), 86400); // 1 day voting period
         }
         token.setVotingContract(address(voting)); // SetVotingContract
         // Distribute tokens


### PR DESCRIPTION
This PR changes the way we instantiate the new contract so that the contract doesn't exist prior to overwriting. Using vm.etch to write over the existing contract address leaves any existing contract state which makes the constructor not work.